### PR TITLE
Password fixes for SamsungTV - fixes #15

### DIFF
--- a/upnpsoap.c
+++ b/upnpsoap.c
@@ -1349,7 +1349,10 @@ static void createPasswordContainer(struct Response *passed_args, const char *id
 		}
 	}
 
-	if (depth == runtime_vars.password_length-1) cnt = 0;
+	if (depth == runtime_vars.password_length-1) {
+		cnt = 0;
+		if (passed_args->client == ESamsungSeriesCDE) cnt = 1;
+	}
 
 	/* DPRINTF(E_DEBUG, L_HTTP, "Generating Password Set:\n"
 	                         " * ObjectID: %s\n"

--- a/upnpsoap.c
+++ b/upnpsoap.c
@@ -1364,7 +1364,7 @@ static void createPasswordContainer(struct Response *passed_args, const char *id
 
 
 	if (depth == runtime_vars.password_length) {
-		if (!isMeta) {
+		if (!isMeta || passed_args->client == ESamsungSeriesCDE) {
 			// Find the First Parent after the Primary Parent
 			for (i=0; id[i] != '$' && i < strlen(id);i++);
 
@@ -1535,6 +1535,10 @@ BrowseContentDirectory(struct upnphttp * h, const char * action)
 		    DPRINTF(E_INFO, L_PASSWORD, "Is Password MetaData %s", ObjectID);
 		    totalMatches = 1;
 		    createPasswordContainer(&args, ObjectID, 1);
+			if ( h->req_client && args.client == ESamsungSeriesCDE ) {
+				DPRINTF(E_INFO, L_HTTP, "Passwords %s\n", args.password);
+				h->req_client->password = args.password;
+			}
         } else {
 			magic = in_magic_container(ObjectID, args.flags, &id);
 			if (magic)


### PR DESCRIPTION
Samsung TV doesn't show the very last folder while navigating the password folders – that's the 4th folder when using password length of 4 – because apparently Samsung TV doesn't like `childcount` of zero and would show the folder as empty when this happens.

The second issue is that the password for Samsung TV – when entered correctly – never get stored, because Samsung TV only sends `BrowseMetadata` flag while browsing the password folders.

This pull request fixes both issues and I've got password protection working properly for my Samsung 7 Series TV, along with other devices.