### PR TITLE
Implement password update when .password file changes (fixes #2)

### DIFF
--- a/monitor_kqueue.c
+++ b/monitor_kqueue.c
@@ -64,6 +64,10 @@ dir_vnode_process(struct event *ev, u_int fflags)
 	wt = (struct watch *)ev->data;
 	path = wt->path;
 
+	// Handle password file changes
+	if ( strcmp(path + strlen(path) - strlen(PASSWORD_FILE), PASSWORD_FILE) == 0 )
+		update_password(path);
+
 	if (fflags & NOTE_DELETE) {
 		DPRINTF(E_DEBUG, L_INOTIFY, "Path [%s] deleted.\n", path);
 		close(ev->fd);

--- a/monitor_kqueue.c
+++ b/monitor_kqueue.c
@@ -66,7 +66,8 @@ dir_vnode_process(struct event *ev, u_int fflags)
 
 	// Handle password file changes
 	if ( strcmp(path + strlen(path) - strlen(PASSWORD_FILE), PASSWORD_FILE) == 0 )
-		update_password(path);
+		if (update_password(path) != 0)
+			DPRINTF(E_ERROR, L_PASSWORD,  "Failed to update password.\n");
 
 	if (fflags & NOTE_DELETE) {
 		DPRINTF(E_DEBUG, L_INOTIFY, "Path [%s] deleted.\n", path);

--- a/scanner.c
+++ b/scanner.c
@@ -769,7 +769,7 @@ ScanDirectory(const char *dir, const char *parent, media_types dir_types, const 
 	int i, n, startID = 0;
 	char *full_path;
 	char *name = NULL;
-	char password[11];
+	char password[PASSWORD_ARRAY_LEN];
 	static long long unsigned int fileno = 0;
 	enum file_types type;
 
@@ -822,9 +822,9 @@ ScanDirectory(const char *dir, const char *parent, media_types dir_types, const 
 		startID = get_next_available_id("OBJECTS", BROWSEDIR_ID);
 	}
 
-	snprintf(full_path, PATH_MAX, "%s/.password", dir);
+	snprintf(full_path, PATH_MAX, "%s/"PASSWORD_FILE, dir);
 	if (access(full_path, 0) == 0) {
-	    readPassword(full_path, password, 11);
+	    readPassword(full_path, password, PASSWORD_ARRAY_LEN);
 	} else {
 	    strcpy(password, currentPassword);
 	}

--- a/upnpglobalvars.h
+++ b/upnpglobalvars.h
@@ -245,4 +245,8 @@ extern volatile short int quitting;
 extern volatile uint32_t updateID;
 extern const char *force_sort_criteria;
 
+/* password */
+#define PASSWORD_FILE ".password"
+#define PASSWORD_ARRAY_LEN 11
+
 #endif


### PR DESCRIPTION
This is a follow up to #21.

As I stated in the previous PR, there were some inconsistent behavior that could happen if a `.password` file were to be modified while the minidlna server was running. I concluded that the best way to fix this was to implement a solution for #2. Also, I fixed some bugs that remained in the previous PR.

The current logic propagates any modification to a `.password` file to all files and directories under its influence, and also respects boundaries between upper and sub directories with different `.password` files. As far as I could test it seems to be working fine. However, more tests are very welcomed, specially in systems that use `kqueue` instead of `inotify` as, although I implemented the logic for triggering the password update in `monitor_kqueue.c`, I don't have a system compatible with it, so I couldn't test it.